### PR TITLE
Swiftformat でエラーになったのでバージョンをあげた

### DIFF
--- a/precommit.sh
+++ b/precommit.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-mint run swiftformat@0.40.11 swiftformat .
+mint run swiftformat@0.40.12 swiftformat .


### PR DESCRIPTION
## 概要

こんなエラーがでた

```
🌱  Cloning SwiftFormat 0.40.11
🌱  Resolving package
🌱  Building package
🌱  Encountered error during "swift build -c release -Xswiftc -target -Xswiftc x86_64-apple-macosx10.14". Use --verbose to see full output
🌱  Failed to build SwiftFormat 0.40.11 with SPM
```

- [x] バージョンを0.40.12にした